### PR TITLE
Add binaries for Mac ARM, Linux ARM, Windows

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -20,6 +20,12 @@ jobs:
       osx_64_numpy1.19python3.9.____cpython:
         CONFIG: osx_64_numpy1.19python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
+      osx_arm64_python3.8.____cpython:
+        CONFIG: osx_arm64_python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_python3.9.____cpython:
+        CONFIG: osx_arm64_python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,6 +8,15 @@ jobs:
     vmImage: vs2017-win2016
   strategy:
     matrix:
+      win_64_numpy1.17python3.6.____cpython:
+        CONFIG: win_64_numpy1.17python3.6.____cpython
+        UPLOAD_PACKAGES: 'True'
+      win_64_numpy1.17python3.7.____cpython:
+        CONFIG: win_64_numpy1.17python3.7.____cpython
+        UPLOAD_PACKAGES: 'True'
+      win_64_numpy1.17python3.8.____cpython:
+        CONFIG: win_64_numpy1.17python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
       win_64_numpy1.19python3.9.____cpython:
         CONFIG: win_64_numpy1.19python3.9.____cpython
         UPLOAD_PACKAGES: 'True'

--- a/.ci_support/linux_aarch64_numpy1.17python3.6.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.17python3.6.____cpython.yaml
@@ -1,0 +1,61 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+boost_cpp:
+- 1.74.0
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+fftw:
+- '3'
+gmp:
+- '6'
+gsl:
+- '2.6'
+hdf5:
+- 1.10.6
+libcblas:
+- 3.8 *netlib
+libprotobuf:
+- '3.15'
+mpfr:
+- '4'
+mpich:
+- '3'
+numpy:
+- '1.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  fftw:
+    max_pin: x
+  gmp:
+    max_pin: x
+  mpfr:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.6.* *_cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/linux_aarch64_numpy1.17python3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.17python3.7.____cpython.yaml
@@ -1,0 +1,61 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+boost_cpp:
+- 1.74.0
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+fftw:
+- '3'
+gmp:
+- '6'
+gsl:
+- '2.6'
+hdf5:
+- 1.10.6
+libcblas:
+- 3.8 *netlib
+libprotobuf:
+- '3.15'
+mpfr:
+- '4'
+mpich:
+- '3'
+numpy:
+- '1.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  fftw:
+    max_pin: x
+  gmp:
+    max_pin: x
+  mpfr:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/linux_aarch64_numpy1.17python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.17python3.8.____cpython.yaml
@@ -1,0 +1,61 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+boost_cpp:
+- 1.74.0
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+fftw:
+- '3'
+gmp:
+- '6'
+gsl:
+- '2.6'
+hdf5:
+- 1.10.6
+libcblas:
+- 3.8 *netlib
+libprotobuf:
+- '3.15'
+mpfr:
+- '4'
+mpich:
+- '3'
+numpy:
+- '1.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  fftw:
+    max_pin: x
+  gmp:
+    max_pin: x
+  mpfr:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/linux_aarch64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.19python3.9.____cpython.yaml
@@ -1,0 +1,61 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+boost_cpp:
+- 1.74.0
+c_compiler:
+- gcc
+c_compiler_version:
+- '9'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+fftw:
+- '3'
+gmp:
+- '6'
+gsl:
+- '2.6'
+hdf5:
+- 1.10.6
+libcblas:
+- 3.8 *netlib
+libprotobuf:
+- '3.15'
+mpfr:
+- '4'
+mpich:
+- '3'
+numpy:
+- '1.19'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  fftw:
+    max_pin: x
+  gmp:
+    max_pin: x
+  mpfr:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/osx_arm64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.8.____cpython.yaml
@@ -1,0 +1,57 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+boost_cpp:
+- 1.74.0
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge/label/rust_dev,conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+fftw:
+- '3'
+gmp:
+- '6'
+gsl:
+- '2.6'
+hdf5:
+- 1.10.6
+libcblas:
+- 3.9 *netlib
+libprotobuf:
+- '3.15'
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpfr:
+- '4'
+mpich:
+- '3'
+numpy:
+- '1.19'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  fftw:
+    max_pin: x
+  gmp:
+    max_pin: x
+  mpfr:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -1,0 +1,57 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+boost_cpp:
+- 1.74.0
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge/label/rust_dev,conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+fftw:
+- '3'
+gmp:
+- '6'
+gsl:
+- '2.6'
+hdf5:
+- 1.10.6
+libcblas:
+- 3.9 *netlib
+libprotobuf:
+- '3.15'
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpfr:
+- '4'
+mpich:
+- '3'
+numpy:
+- '1.19'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  fftw:
+    max_pin: x
+  gmp:
+    max_pin: x
+  mpfr:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy

--- a/.ci_support/win_64_numpy1.17python3.6.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.17python3.6.____cpython.yaml
@@ -1,0 +1,41 @@
+boost_cpp:
+- 1.74.0
+c_compiler:
+- vs2017
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2017
+fftw:
+- '3'
+gsl:
+- '2.6'
+hdf5:
+- 1.10.6
+libcblas:
+- 3.8 *netlib
+libprotobuf:
+- '3.15'
+mpfr:
+- '4'
+numpy:
+- '1.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  fftw:
+    max_pin: x
+  mpfr:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.6.* *_cpython
+target_platform:
+- win-64
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/win_64_numpy1.17python3.7.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.17python3.7.____cpython.yaml
@@ -1,0 +1,41 @@
+boost_cpp:
+- 1.74.0
+c_compiler:
+- vs2017
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2017
+fftw:
+- '3'
+gsl:
+- '2.6'
+hdf5:
+- 1.10.6
+libcblas:
+- 3.8 *netlib
+libprotobuf:
+- '3.15'
+mpfr:
+- '4'
+numpy:
+- '1.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  fftw:
+    max_pin: x
+  mpfr:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+target_platform:
+- win-64
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/win_64_numpy1.17python3.8.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.17python3.8.____cpython.yaml
@@ -1,0 +1,41 @@
+boost_cpp:
+- 1.74.0
+c_compiler:
+- vs2017
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2017
+fftw:
+- '3'
+gsl:
+- '2.6'
+hdf5:
+- 1.10.6
+libcblas:
+- 3.8 *netlib
+libprotobuf:
+- '3.15'
+mpfr:
+- '4'
+numpy:
+- '1.17'
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  fftw:
+    max_pin: x
+  mpfr:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+target_platform:
+- win-64
+zip_keys:
+- - python
+  - numpy

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,124 @@
+---
+kind: pipeline
+name: linux_aarch64_numpy1.17python3.6.____cpython
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Install and build
+  image: quay.io/condaforge/linux-anvil-aarch64
+  environment:
+    CONFIG: linux_aarch64_numpy1.17python3.6.____cpython
+    UPLOAD_PACKAGES: True
+    PLATFORM: linux-aarch64
+    BINSTAR_TOKEN:
+      from_secret: BINSTAR_TOKEN
+    FEEDSTOCK_TOKEN:
+      from_secret: FEEDSTOCK_TOKEN
+    STAGING_BINSTAR_TOKEN:
+      from_secret: STAGING_BINSTAR_TOKEN
+  commands:
+    - export FEEDSTOCK_ROOT="$DRONE_WORKSPACE"
+    - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"
+    - export CI=drone
+    - export GIT_BRANCH="$DRONE_BRANCH"
+    - export FEEDSTOCK_NAME=$(basename ${DRONE_REPO_NAME})
+    - sed -i '$ichown -R conda:conda "$FEEDSTOCK_ROOT"' /opt/docker/bin/entrypoint
+    - /opt/docker/bin/entrypoint $FEEDSTOCK_ROOT/.scripts/build_steps.sh
+    - echo "Done building"
+
+---
+kind: pipeline
+name: linux_aarch64_numpy1.17python3.7.____cpython
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Install and build
+  image: quay.io/condaforge/linux-anvil-aarch64
+  environment:
+    CONFIG: linux_aarch64_numpy1.17python3.7.____cpython
+    UPLOAD_PACKAGES: True
+    PLATFORM: linux-aarch64
+    BINSTAR_TOKEN:
+      from_secret: BINSTAR_TOKEN
+    FEEDSTOCK_TOKEN:
+      from_secret: FEEDSTOCK_TOKEN
+    STAGING_BINSTAR_TOKEN:
+      from_secret: STAGING_BINSTAR_TOKEN
+  commands:
+    - export FEEDSTOCK_ROOT="$DRONE_WORKSPACE"
+    - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"
+    - export CI=drone
+    - export GIT_BRANCH="$DRONE_BRANCH"
+    - export FEEDSTOCK_NAME=$(basename ${DRONE_REPO_NAME})
+    - sed -i '$ichown -R conda:conda "$FEEDSTOCK_ROOT"' /opt/docker/bin/entrypoint
+    - /opt/docker/bin/entrypoint $FEEDSTOCK_ROOT/.scripts/build_steps.sh
+    - echo "Done building"
+
+---
+kind: pipeline
+name: linux_aarch64_numpy1.17python3.8.____cpython
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Install and build
+  image: quay.io/condaforge/linux-anvil-aarch64
+  environment:
+    CONFIG: linux_aarch64_numpy1.17python3.8.____cpython
+    UPLOAD_PACKAGES: True
+    PLATFORM: linux-aarch64
+    BINSTAR_TOKEN:
+      from_secret: BINSTAR_TOKEN
+    FEEDSTOCK_TOKEN:
+      from_secret: FEEDSTOCK_TOKEN
+    STAGING_BINSTAR_TOKEN:
+      from_secret: STAGING_BINSTAR_TOKEN
+  commands:
+    - export FEEDSTOCK_ROOT="$DRONE_WORKSPACE"
+    - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"
+    - export CI=drone
+    - export GIT_BRANCH="$DRONE_BRANCH"
+    - export FEEDSTOCK_NAME=$(basename ${DRONE_REPO_NAME})
+    - sed -i '$ichown -R conda:conda "$FEEDSTOCK_ROOT"' /opt/docker/bin/entrypoint
+    - /opt/docker/bin/entrypoint $FEEDSTOCK_ROOT/.scripts/build_steps.sh
+    - echo "Done building"
+
+---
+kind: pipeline
+name: linux_aarch64_numpy1.19python3.9.____cpython
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Install and build
+  image: quay.io/condaforge/linux-anvil-aarch64
+  environment:
+    CONFIG: linux_aarch64_numpy1.19python3.9.____cpython
+    UPLOAD_PACKAGES: True
+    PLATFORM: linux-aarch64
+    BINSTAR_TOKEN:
+      from_secret: BINSTAR_TOKEN
+    FEEDSTOCK_TOKEN:
+      from_secret: FEEDSTOCK_TOKEN
+    STAGING_BINSTAR_TOKEN:
+      from_secret: STAGING_BINSTAR_TOKEN
+  commands:
+    - export FEEDSTOCK_ROOT="$DRONE_WORKSPACE"
+    - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"
+    - export CI=drone
+    - export GIT_BRANCH="$DRONE_BRANCH"
+    - export FEEDSTOCK_NAME=$(basename ${DRONE_REPO_NAME})
+    - sed -i '$ichown -R conda:conda "$FEEDSTOCK_ROOT"' /opt/docker/bin/entrypoint
+    - /opt/docker/bin/entrypoint $FEEDSTOCK_ROOT/.scripts/build_steps.sh
+    - echo "Done building"
+

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -37,6 +37,10 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
+     EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+fi
+
 
 ( endgroup "Configuring conda" ) 2> /dev/null
 

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -53,6 +53,10 @@ source run_conda_forge_build_setup
 echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+fi
+
 conda $BUILD_CMD ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
 ( startgroup "Validating outputs" ) 2> /dev/null
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,14 @@ Current build status
 ====================
 
 
-<table>
+<table><tr>
+    <td>Drone</td>
+    <td>
+      <a href="https://cloud.drone.io/conda-forge/imp-feedstock">
+        <img alt="linux" src="https://img.shields.io/drone/build/conda-forge/imp-feedstock/master.svg?label=Linux">
+      </a>
+    </td>
+  </tr>
     
   <tr>
     <td>Azure</td>
@@ -63,6 +70,34 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_aarch64_numpy1.17python3.6.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13055&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imp-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.17python3.6.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_numpy1.17python3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13055&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imp-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.17python3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_numpy1.17python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13055&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imp-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.17python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_numpy1.19python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13055&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imp-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_numpy1.19python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64_numpy1.17python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13055&branchName=master">
@@ -88,6 +123,41 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13055&branchName=master">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imp-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.19python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13055&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imp-feedstock?branchName=master&jobName=osx&configuration=osx_arm64_python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13055&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imp-feedstock?branchName=master&jobName=osx&configuration=osx_arm64_python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_numpy1.17python3.6.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13055&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imp-feedstock?branchName=master&jobName=win&configuration=win_64_numpy1.17python3.6.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_numpy1.17python3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13055&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imp-feedstock?branchName=master&jobName=win&configuration=win_64_numpy1.17python3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_numpy1.17python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13055&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imp-feedstock?branchName=master&jobName=win&configuration=win_64_numpy1.17python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,1 +1,4 @@
+build_platform: {osx_arm64: osx_64}
 conda_forge_output_validation: true
+provider: {linux_aarch64: default}
+test_on_native_only: true

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,20 +3,18 @@ echo on
 echo "Resolve symlinks"
 
 :: tools/dev_tools is a symlink, but many Windows variants don't support
-:: links, so copy the original contents if necessary
-IF NOT EXIST "tools\dev_tools\README.md" (
-  dir tools
-  rename tools\dev_tools dev_tools.old
-  if errorlevel 1 exit 1
-  mkdir tools\dev_tools
-  if errorlevel 1 exit 1
-  copy modules\rmf\dependency\RMF\tools\dev_tools\* tools\dev_tools\
-  if errorlevel 1 exit 1
-  mkdir tools\dev_tools\python_tools
-  if errorlevel 1 exit 1
-  copy modules\rmf\dependency\RMF\tools\dev_tools\python_tools\* tools\dev_tools\python_tools\
-  if errorlevel 1 exit 1
-)
+:: links, so copy the original contents instead
+dir tools
+rename tools\dev_tools dev_tools.old
+if errorlevel 1 exit 1
+mkdir tools\dev_tools
+if errorlevel 1 exit 1
+copy modules\rmf\dependency\RMF\tools\dev_tools\* tools\dev_tools\
+if errorlevel 1 exit 1
+mkdir tools\dev_tools\python_tools
+if errorlevel 1 exit 1
+copy modules\rmf\dependency\RMF\tools\dev_tools\python_tools\* tools\dev_tools\python_tools\
+if errorlevel 1 exit 1
 
 echo "Build app wrapper"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,8 @@ build:
 
 requirements:
   build:
+    - python                                 # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - llvm-openmp  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,7 @@ source:
     - imp-directories.patch  # [win]
 
 build:
-  number: 0
-  skip: true  # [win and py < 39]
+  number: 1
   detect_binary_files_with_prefix: True  # [not win]
 
 requirements:


### PR DESCRIPTION
This should enable cross-compilation to build binaries for Mac ARM (Apple Silicon) and also enables builds for all supported Python versions on both Windows and aarch64 Linux.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
