### PR TITLE
Build Mac Python extensions with 2-level namespace

### DIFF
--- a/recipe/mac-python-two-level-namespace.patch
+++ b/recipe/mac-python-two-level-namespace.patch
@@ -1,0 +1,57 @@
+diff --git a/modules/core/dependency/python-ihm.cmake b/modules/core/dependency/python-ihm.cmake
+index 0c2098894a..047e5e9845 100644
+--- a/modules/core/dependency/python-ihm.cmake
++++ b/modules/core/dependency/python-ihm.cmake
+@@ -85,7 +85,7 @@ add_library(ihm-python MODULE ${wrap_c} ${ext_c})
+ # Apple linkers complain by default if there are undefined symbols
+ if(APPLE)
+   set_target_properties(ihm-python
+-                 PROPERTIES LINK_FLAGS "-flat_namespace -undefined suppress")
++                 PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+ endif(APPLE)
+ 
+ target_link_libraries(ihm-python ${IMP_SWIG_LIBRARIES})
+diff --git a/modules/rmf/dependency/RMF/swig/CMakeLists.txt b/modules/rmf/dependency/RMF/swig/CMakeLists.txt
+index a735b9787d..2c44f1a2c1 100644
+--- a/modules/rmf/dependency/RMF/swig/CMakeLists.txt
++++ b/modules/rmf/dependency/RMF/swig/CMakeLists.txt
+@@ -33,7 +33,7 @@ ENDIF()
+ 
+ set_property(TARGET "${SWIG_MODULE_RMF_REAL_NAME}" PROPERTY FOLDER "RMF")
+ if(APPLE)
+-  set_target_properties("${SWIG_MODULE_RMF_REAL_NAME}" PROPERTIES LINK_FLAGS "-flat_namespace -undefined suppress")
++  set_target_properties("${SWIG_MODULE_RMF_REAL_NAME}" PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+ endif(APPLE)
+ set_target_properties("${SWIG_MODULE_RMF_REAL_NAME}" PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+ 
+@@ -72,7 +72,7 @@ ENDIF()
+ 
+ set_property(TARGET "${SWIG_MODULE_RMF_HDF5_REAL_NAME}" PROPERTY FOLDER "RMF")
+ if(APPLE)
+-  set_target_properties("${SWIG_MODULE_RMF_HDF5_REAL_NAME}" PROPERTIES LINK_FLAGS "-flat_namespace -undefined suppress")
++  set_target_properties("${SWIG_MODULE_RMF_HDF5_REAL_NAME}" PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+ endif(APPLE)
+ set_target_properties("${SWIG_MODULE_RMF_HDF5_REAL_NAME}" PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+ 
+@@ -93,7 +93,7 @@ ENDIF(WIN32)
+ # Apple linkers complain by default if there are undefined symbols
+ IF(APPLE)
+   SET(CMAKE_SHARED_MODULE_CREATE_CXX_FLAGS
+-    "${CMAKE_SHARED_MODULE_CREATE_CXX_FLAGS} -flat_namespace -undefined suppress")
++    "${CMAKE_SHARED_MODULE_CREATE_CXX_FLAGS} -undefined dynamic_lookup")
+ ENDIF(APPLE)
+ 
+ INSTALL(TARGETS ${SWIG_MODULE_RMF_HDF5_REAL_NAME} DESTINATION ${CMAKE_INSTALL_PYTHONDIR})
+diff --git a/tools/build/cmake_templates/ModuleSwig.cmake b/tools/build/cmake_templates/ModuleSwig.cmake
+index 073d7914da..f8f2319d62 100644
+--- a/tools/build/cmake_templates/ModuleSwig.cmake
++++ b/tools/build/cmake_templates/ModuleSwig.cmake
+@@ -57,7 +57,7 @@ add_custom_command(OUTPUT ${source} ${wrap_py} ${wrap_py_orig}
+ add_library(IMP.%(name)s-python MODULE ${source})
+ # Apple linkers complain by default if there are undefined symbols
+ if(APPLE)
+-  set_target_properties(IMP.%(name)s-python PROPERTIES LINK_FLAGS "-flat_namespace -undefined suppress")
++  set_target_properties(IMP.%(name)s-python PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+ endif(APPLE)
+ 
+ set_target_properties(IMP.%(name)s-python PROPERTIES PREFIX ""

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,10 +9,11 @@ source:
   url: https://github.com/salilab/imp/releases/download/{{ version }}/imp-src-{{ version }}.tar.gz
   sha256: 2667f7a4f7b4830ba27e0d41e2cab0fc21ca22176625bfd8b2f353b283dfc8af
   patches:
+    - mac-python-two-level-namespace.patch
     - imp-directories.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: True  # [not win]
 
 requirements:

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -37,6 +37,15 @@ del r
 
 os.unlink("test.rmf")
 
+# Make sure we can print objects without segfaulting (due to mismatch
+# between conda and OS-provided libc++.1.dylib;
+# see https://github.com/salilab/imp/issues/1062)
+m = IMP.Model()
+p = IMP.Particle(m)
+xyz = IMP.core.XYZ.setup_particle(p, IMP.algebra.Vector3D(1,2,3))
+h = IMP.atom.Hierarchy(p)
+strh = str(h)
+
 # Make sure that IMP.domino was built with HDF5 support
 x = IMP.domino.ReadHDF5AssignmentContainer
 


### PR DESCRIPTION
This avoids a segfault when trying to pass
C++ objects between our Python extensions
and the underlying C++ libraries, due to a
mismatch between conda-provided and OS-provided
libc++.1.dylib. Relates salilab/imp#1062.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
