### PR TITLE
Reenable msmpi for Windows builds

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -39,9 +39,6 @@ set PERCPPCOMP="-DIMP_PER_CPP_COMPILATION=cgal"
 :: Don't build the scratch or cnmultifit modules
 set DISABLED="scratch:cnmultifit"
 
-:: Modules that use MPI
-set MPIMODS="mpi:nestor:spb"
-
 :: We use the conda boost package, which includes
 :: zlib support, but defining BOOST_ALL_DYN_LINK (below) makes boost try to
 :: link against boost_zlib*.lib, which doesn't exist. Override this by
@@ -63,7 +60,7 @@ if errorlevel 1 exit 1
 
 :: Make sure all modules we asked for were found (this is tested for
 :: in the final package, but quicker to abort here if they're missing)
-python "%RECIPE_DIR%\check_disabled_modules.py" %DISABLED% %MPIMODS%
+python "%RECIPE_DIR%\check_disabled_modules.py" %DISABLED%
 if errorlevel 1 exit 1
 
 :: Often builds fail on Windows on conda-forge's build hosts

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - imp-abseil-windows.patch  # [win]
 
 build:
-  number: 4
+  number: 5
   detect_binary_files_with_prefix: True  # [not win]
 
 requirements:
@@ -55,10 +55,7 @@ requirements:
     - mpir  # [win]
     - mpfr
     - mpich  # [not win]
-    # We don't currently support MPI on Windows. This would use the msmpi
-    # package, which needs to be rebuilt with a more modern toolchain:
-    # https://github.com/conda-forge/msmpi-feedstock/pull/21
-
+    - msmpi  # [win]
     # We use SWIG classes from the rmf package, so we must ensure we're
     # using the same version of the SWIG runtime
     - swig-abi
@@ -68,6 +65,7 @@ requirements:
     - {{ pin_compatible('rmf', max_pin='x.x') }}
     - ihm
     - protobuf
+    - msmpi  # [win]
 
 test:
   # Need Eigen to test IMPConfig.cmake
@@ -84,13 +82,13 @@ test:
     - IMP.bayesianem
     - IMP.sampcon
     - IMP.rmf
-    - IMP.mpi  # [not win]
-    - IMP.spb  # [not win]
+    - IMP.mpi
+    - IMP.spb
     - RMF
   # Command line tools
   commands:
     - foxs --help
-    - spb_test_score --help  # [not win]
+    - spb_test_score --help
     - imp_sampcon --help
     - multifit --help
 


### PR DESCRIPTION
Now that msmpi has been rebuilt with a newer toolchain thanks to conda-forge/msmpi-feedstock#25, we should be able to use it with opencv again.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
